### PR TITLE
Fix personal color

### DIFF
--- a/config/idols/51_tsumugi.yml
+++ b/config/idols/51_tsumugi.yml
@@ -25,7 +25,7 @@ tsumugi:
   - 三味線
   favorites:
   - 和スイーツ
-  color: "#e6dcf7"
+  color: "#ebe1ff"
   cv: 南早紀
   birthplace: 石川県
   idol_image: 

--- a/config/idols/52_kaori.yml
+++ b/config/idols/52_kaori.yml
@@ -25,7 +25,7 @@ kaori:
   favorites:
   - 子ども
   - 洋菓子
-  color: "#28417d"
+  color: "#274079"
   cv: 香里有佐
   birthplace: 東京都
   idol_image: 


### PR DESCRIPTION
日本語で失礼します。(英語だと説明しづらいので…)

紬ちゃんと歌織さんのパーソナルカラーについて、修正の提案です。

ミリシタの名刺機能で、各アイドルのパーソナルカラーを使った名刺を作ることができるようになってますが、作った名刺をスクショしてカラーピッカーにかけたところ、新規の二人のカラーコードがrubimasのものと違っていました。あくまで画像なので多少の違いは出るのかと思って、他のアイドルのも試してみましたが、そちらはピタリと一致します。なので、カラーピッカーにかけた色に変更してみました。

ちなみに、今のカラーコードはどちらから取られたものでしょうか？(そちらのほうが公式と言えるかもしれないので…)