### PR TITLE
feat: support for ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - ruby-head
 matrix:
   allow_failures:
@@ -13,3 +14,4 @@ matrix:
 before_install:
   - travis_retry gem install bundler -v 2.0.1 --no-document || travis_retry gem install bundler --no-document -v 1.17.3
   - travis_retry gem update --system || travis_retry gem update --system 2.7.8
+script: bundle exec rake

--- a/lib/rubimas/idol.rb
+++ b/lib/rubimas/idol.rb
@@ -52,7 +52,7 @@ module Rubimas
       end
 
       def all
-        @@all_idols ||= config.map { |key, prof| prof[:key] = key; new(prof) }.sort_by { |idol| idol.id }
+        @@all_idols ||= config.map { |key, prof| prof[:key] = key; new(**prof) }.sort_by { |idol| idol.id }
       end
       alias_method :all_idols, :all
 


### PR DESCRIPTION
support for ruby 2.7

- fix keyword argument warning
- add version on .travisci.yml

```sh
# before fix
$ ruby --version
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin19]
$ bundle exec rspec
Randomized with seed 18888

Supported 765 Production idols.
  When Idol.#<name>
    name: :kana
lib/rubimas/idol.rb:55: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
lib/rubimas/idol.rb:9: warning: The called method `initialize' is defined here
      is expected to be an instance of Rubimas::Idol::Name
      is expected to be an instance of Rubimas::Idol
      is expected not to raise Exception
.....
```